### PR TITLE
[RCIAM-1089] Device Code flow fails for confidential clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Full Keycloak upstream jira issue can be shown if filtered by Fix version.
 
 Our Keycloak version is working well with PostgreSQL database. For using other SQL databases, text field in database need to be evaluated.
 
+## [Unreleased]
+
+### Fixed
+
+- Fix bug when `client_secret` is not defined in the device authorization request [RCIAM-1089](https://jira.argo.grnet.gr/browse/RCIAM-1089)
+
 ## [16.1.0-2.10] - 2022-07-25
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <quarkus.version>2.5.3.Final</quarkus.version>
-        <eosc-kc.version>${project.version}-2.10</eosc-kc.version>
+        <eosc-kc.version>${project.version}-2.11rc1</eosc-kc.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/ClientIdAndSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/ClientIdAndSecretAuthenticator.java
@@ -56,6 +56,7 @@ public class ClientIdAndSecretAuthenticator extends AbstractClientAuthenticator 
         String clientSecret = null;
 
         String authorizationHeader = context.getHttpRequest().getHttpHeaders().getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        String requestPath = context.getSession().getContext().getUri().getPath();
 
         MediaType mediaType = context.getHttpRequest().getHttpHeaders().getMediaType();
         boolean hasFormData = mediaType != null && mediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
@@ -116,6 +117,12 @@ public class ClientIdAndSecretAuthenticator extends AbstractClientAuthenticator 
 
         // Skip client_secret validation for public client
         if (client.isPublicClient()) {
+            context.success();
+            return;
+        }
+
+        // Skip client_secret validation for Device Code flow
+        if (requestPath.endsWith("/protocol/openid-connect/auth/device")) {
             context.success();
             return;
         }


### PR DESCRIPTION
# Summary

This PR fixes the bug when `client_secret` is not defined in the device authorization request. 